### PR TITLE
join and leave events onclick

### DIFF
--- a/src/utils/data/eventData.js
+++ b/src/utils/data/eventData.js
@@ -1,12 +1,12 @@
 import { clientCredentials } from '../client';
 
-const getEvents = () =>
-  new Promise((resolve, reject) => {
-    fetch(`${clientCredentials.databaseURL}/events`)
-      .then((response) => response.json())
-      .then(resolve)
-      .catch(reject);
-  });
+const getEvents = (uid) =>
+  fetch(`${clientCredentials.databaseURL}/events`, {
+    method: 'GET',
+    headers: {
+      Authorization: uid,
+    },
+  }).then((res) => res.json());
 
 const createEvent = (event) =>
   new Promise((resolve, reject) => {
@@ -57,6 +57,28 @@ const deleteEvent = (id) =>
     })
       .then((res) => (res.ok ? resolve(true) : reject(new Error('Failed to delete event'))))
       .catch(reject);
+  });
+
+const endpoint = `${clientCredentials.databaseURL}/events`;
+
+export const joinEvent = (eventId, uid) =>
+  fetch(`${endpoint}/${eventId}/signup`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid, // ← no Bearer/Token prefix
+    },
+    body: JSON.stringify({ user_id: uid }), // Use user_id to match backend
+  }).then((res) => res.json());
+
+export const leaveEvent = (eventId, uid) =>
+  fetch(`${endpoint}/${eventId}/leave`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid,
+    },
+    body: JSON.stringify({ user_id: uid }), // Send user_id in body for backend compatibility
   });
 
 // Export both functions


### PR DESCRIPTION
This pull request introduces functionality for users to join and leave events, along with updates to ensure the event list dynamically refreshes based on user actions. The changes primarily involve updates to the `EventsPage` and `EventCard` components, as well as modifications to the `eventData` utility functions to support the new features.

### Frontend Changes:

* **Dynamic Event Refreshing:**
  - Added a `refreshEvents` helper function in `pages/events/index.js` to re-fetch events based on the authenticated user's `uid`. This ensures the event list updates dynamically when events are joined, left, or deleted.
  - Updated the `useEffect` dependency in `EventsPage` to trigger data fetching whenever the `user?.uid` changes.

* **Event Joining and Leaving:**
  - Enhanced the `EventCard` component to include `Join` and `Leave` buttons, which call `joinEvent` and `leaveEvent` functions respectively. These buttons are conditionally rendered based on whether the user has already joined the event.
  - Added `joined` and `onUpdate` props to `EventCard` to handle the join/leave state and trigger event list updates. Updated the PropTypes to reflect these new props. [[1]](diffhunk://#diff-a95bc521ceae98c7ea6fb87edc2d6cf92ba359bf5c7e9a6b0171ff65e350f30bR2-R33) [[2]](diffhunk://#diff-a95bc521ceae98c7ea6fb87edc2d6cf92ba359bf5c7e9a6b0171ff65e350f30bR75-R76)

### Backend Integration:

* **Authorization in Event Fetching:**
  - Modified the `getEvents` function in `src/utils/data/eventData.js` to accept a `uid` parameter and include it as an `Authorization` header. This allows the backend to return user-specific event data.

* **Join and Leave Event API Calls:**
  - Added `joinEvent` and `leaveEvent` functions in `src/utils/data/eventData.js` to handle POST and DELETE requests for signing up and leaving events, respectively. These functions include the necessary headers and body payload to comply with backend requirements.